### PR TITLE
Close file descriptor for config.txt

### DIFF
--- a/jill.py
+++ b/jill.py
@@ -14,8 +14,8 @@ logging.basicConfig(format='%(asctime)s - %(name)s - %(levelname)s - %(message)s
                     level=logging.INFO)
 
 logger = logging.getLogger(__name__)
-configFile = open("config.txt", "r") #Replace that line with YOUR config.txt
-token = str(configFile.readline())
+with open("config.txt", "r") as configFile:#Replace that line with YOUR config.txt
+    token = str(configFile.readline())
 
 def start(bot, update):
     


### PR DESCRIPTION
Jill does not call close() on the configFile and leaves it open for the duration of the program

Use a context manager to close the fd as soon as it completes